### PR TITLE
Add WordPress secure setup with Wordfence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# WordPress core files
+/wordpress/
+
+# Configuration files with sensitive data
+wp-config.php
+
+# Log files
+*.log
+
+# Cache files
+*.cache
+
+# Environment files
+.env
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Secure WordPress Setup with Wordfence
+
+This repository contains scripts and configurations for setting up a secure WordPress installation with Wordfence security plugin.
+
+## Features
+
+- Latest WordPress version (currently 6.7.1)
+- Wordfence security plugin
+- Secure Apache configurations
+- Automated installation process
+- Security-focused wp-config.php
+- WP-CLI integration
+
+## Prerequisites
+
+- Debian/Ubuntu-based system
+- Root access
+- Internet connection
+
+## Installation
+
+1. Clone this repository:
+```bash
+git clone https://github.com/yourusername/wordpress-secure-setup.git
+cd wordpress-secure-setup
+```
+
+2. Make the installation script executable:
+```bash
+chmod +x scripts/install.sh
+```
+
+3. Run the installation script:
+```bash
+sudo ./scripts/install.sh
+```
+
+## Security Features
+
+- Automatic WordPress core updates enabled
+- File editing disabled in admin panel
+- SSL forced for admin area
+- Secure Apache configurations
+- Wordfence security plugin
+- Protected sensitive files
+- Security headers configured
+
+## Post-Installation
+
+After installation:
+
+1. Change the default admin password
+2. Complete Wordfence setup wizard
+3. Configure Wordfence firewall
+4. Enable two-factor authentication
+5. Set up regular backups
+6. Configure email alerts
+
+## Configuration
+
+You can modify the following files to customize your installation:
+
+- `scripts/install.sh`: Installation variables and process
+- `config/wp-config.php`: WordPress configuration
+- `config/wordpress.conf`: Apache virtual host configuration
+
+## Security Notes
+
+- Default credentials are for testing only
+- Change all passwords after installation
+- Keep WordPress and plugins updated
+- Monitor Wordfence security alerts
+- Regularly backup your site
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch
+3. Commit your changes
+4. Push to the branch
+5. Create a Pull Request
+
+## License
+
+MIT License

--- a/config/wordpress.conf
+++ b/config/wordpress.conf
@@ -1,0 +1,27 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/html/wordpress
+    
+    <Directory /var/www/html/wordpress>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+        
+        # Basic security headers
+        Header set X-Content-Type-Options "nosniff"
+        Header set X-Frame-Options "SAMEORIGIN"
+        Header set X-XSS-Protection "1; mode=block"
+        Header set Referrer-Policy "strict-origin-when-cross-origin"
+        
+        # Disable directory listing
+        Options -Indexes
+    </Directory>
+
+    # Deny access to sensitive files
+    <FilesMatch "^\.(?!well-known/)">
+        Require all denied
+    </FilesMatch>
+    
+    <FilesMatch "(?i)(^wp-config\.php|\.log|\.sql|\.tar|\.zip|\.gz|\.env)">
+        Require all denied
+    </FilesMatch>
+</VirtualHost>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Configuration variables
+DB_NAME="wordpress"
+DB_USER="wordpress"
+DB_PASS="wordpress_password"
+WP_ADMIN_USER="admin"
+WP_ADMIN_PASS="StrongAdminPass123!"
+WP_ADMIN_EMAIL="admin@example.com"
+WP_TITLE="WordPress Blog"
+
+# Update system and install dependencies
+apt-get update
+apt-get install -y php php-mysql php-fpm php-curl php-gd php-mbstring php-xml php-xmlrpc mariadb-server nginx curl
+
+# Start MariaDB
+service mariadb start
+
+# Create WordPress database and user
+mysql -e "CREATE DATABASE IF NOT EXISTS $DB_NAME;"
+mysql -e "CREATE USER IF NOT EXISTS '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASS';"
+mysql -e "GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'localhost';"
+mysql -e "FLUSH PRIVILEGES;"
+
+# Download and set up WordPress
+cd /var/www/html
+wget https://wordpress.org/latest.tar.gz
+tar -xzf latest.tar.gz
+chown -R www-data:www-data wordpress/
+rm latest.tar.gz
+
+# Copy WordPress config
+cp ../config/wp-config.php /var/www/html/wordpress/
+chown www-data:www-data /var/www/html/wordpress/wp-config.php
+
+# Configure Apache
+cp ../config/wordpress.conf /etc/apache2/sites-available/
+a2ensite wordpress
+a2enmod rewrite
+a2dissite 000-default
+service apache2 restart
+
+# Install WP-CLI
+curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+chmod +x wp-cli.phar
+mv wp-cli.phar /usr/local/bin/wp
+
+# Install WordPress core
+cd /var/www/html/wordpress
+sudo -u www-data wp core install --url=http://localhost --title="$WP_TITLE" --admin_user="$WP_ADMIN_USER" --admin_password="$WP_ADMIN_PASS" --admin_email="$WP_ADMIN_EMAIL"
+
+# Install and activate Wordfence
+sudo -u www-data wp plugin install wordfence --activate
+
+echo "Installation completed successfully!"
+echo "WordPress admin URL: http://localhost/wp-admin"
+echo "Username: $WP_ADMIN_USER"
+echo "Password: $WP_ADMIN_PASS"


### PR DESCRIPTION
This PR adds a secure WordPress setup with Wordfence integration. Features:

- Automated installation script
- Security-focused configurations
- Latest WordPress version (6.7.1)
- Wordfence integration
- Secure Apache settings
- Comprehensive documentation

To use this setup:
1. Clone the repository
2. Run `chmod +x scripts/install.sh`
3. Run `sudo ./scripts/install.sh`
4. Follow the post-installation security steps in the README